### PR TITLE
Optimize DISCOVERING_HOSTS_WITH_TCPSYNCHRONIZATION function

### DIFF
--- a/Nmap-Warrior/nmap-warrior.sh
+++ b/Nmap-Warrior/nmap-warrior.sh
@@ -309,12 +309,11 @@ function DISCOVERING_HOSTS_WITH_PING(){
 # ------------------------------------------------------------------
 
 function DISCOVERING_HOSTS_WITH_TCPSYNCHRONIZATION(){
-
-      nmap -v -n -sn -PS21,22,23,25,53,80,110,111,135,139,143,443,445,993,995,1723,3306,3389,5900,8080 -iL "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$DOWN_HOSTS_FILE" -oA "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$TEMP_DIR"/LIVE-HOSTS-TRY-2 2>> "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$LOG_FILE" &> /dev/null
-
-      cat "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$TEMP_DIR"/LIVE-HOSTS-TRY-2.gnmap | grep Up | cut -f 2 -d " " >> "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$LIVE_HOSTS_FILE" 2>> "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$LOG_FILE"
-
-      cat "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$TEMP_DIR"/LIVE-HOSTS-TRY-2.gnmap | grep Down | cut -f 2 -d " " > "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$DOWN_HOSTS_FILE" 2>> "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$LOG_FILE"
+    nmap -v -n -sn -PS21,22,23,25,53,80,110,111,135,139,143,443,445,993,995,1723,3306,3389,5900,8080 \
+        $(cat "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$DOWN_HOSTS_FILE" | xargs) \
+        -oG "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$TEMP_DIR"/LIVE-HOSTS-TRY-2 \
+        2>> "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$LOG_FILE" | tee /dev/stdout \
+        | grep -v Down | cut -f 2 -d " " >> "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$LIVE_HOSTS_FILE" 2>> "$MAIN_OUTPUT_DIR"/"$NMAP_OUTPUT_DIR"/"$LOG_FILE"
 }
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
This commit modifies the DISCOVERING_HOSTS_WITH_TCPSYNCHRONIZATION function to use the -oG option of nmap and xargs to pass the list of hosts as arguments, which should improve the performance of the function. The grep and cut commands have also been modified to only run once, and the output of the nmap command is now logged to a file and displayed on the screen using tee. These changes should make the function faster and more efficient.